### PR TITLE
Fix random.score, miner OOM and add alive uids

### DIFF
--- a/distributed_training/__init__.py
+++ b/distributed_training/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # version nomenclature = __training_type__.__model__.__other_changes__
-__version__ = "1.1.8"
+__version__ = "1.1.9"
 __run__ = "6"
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/distributed_training/base/validator.py
+++ b/distributed_training/base/validator.py
@@ -173,8 +173,9 @@ class BaseValidatorNeuron(BaseNeuron):
 
                 current_global_epoch = self.global_progress.epoch
                 self.global_progress.epoch = get_global_epoch(self)
-                if (self.local_progress.epoch != self.global_progress.epoch) or (
-                    not self.all_reduce_success_status
+                if (self.blocks_since_allreduce > 100) and (
+                    (self.local_progress.epoch != self.global_progress.epoch)
+                    or (not self.all_reduce_success_status)
                 ):
                     if self.local_progress.epoch != self.global_progress.epoch:
                         self.logger.info(
@@ -510,7 +511,6 @@ class BaseValidatorNeuron(BaseNeuron):
                         sigma=self.uid_tracker[uid].train.openskill_rating.sigma,
                         name=str(uid),
                     )
-
         elif os.path.isfile(self.config.neuron.full_path + "/state.pt"):
             self.logger.info(
                 "Pre-saved validator state found in .pt format. Loading validator state."

--- a/distributed_training/utils/config.py
+++ b/distributed_training/utils/config.py
@@ -143,14 +143,14 @@ def add_args(cls, parser, prefix=None):
         nargs="+",
         help="The addresses for the DHT",
         default=[
-            "/ip4/161.97.156.125/tcp/8000/p2p/12D3KooWRXATj82cqk2zi7uZ2Q1soPuML8ietJXM6RdGnMHGB73U",
+            "/ip4/161.97.156.125/tcp/8000/p2p/12D3KooWBcqjBjr7jHMHtrKtDtduPxuv7KKankS7qXif253N8k4y",
         ],
     )
     parser.add_argument(
         "--neuron.blocks_per_allreduce",
         type=int,
         help="Amount of blocks between each all reduce",
-        default=1800,
+        default=500,
     )
 
     parser.add_argument(

--- a/distributed_training/utils/uids.py
+++ b/distributed_training/utils/uids.py
@@ -167,6 +167,8 @@ def get_next_uid_api(self):
         uids = response.json()["uids"]
 
         assert uids != self.miner_uids
+        assert type(uids) == list
+        assert all(isinstance(uid, int) for uid in uids)
         return uids
     except Exception as e:
         self.logger.info(

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -504,9 +504,9 @@ class Miner(BaseMinerNeuron):
 
             # Ensure the gradient is on the same device as the parameter.
             assert p is not None
-            grad = p.to(p.device)
+            grad = p.detach().to(p.device)
             if self.error_feedback[n].device != p.device:
-                self.error_feedback[n] = self.error_feedback[n].to(p.device)
+                self.error_feedback[n] = self.error_feedback[n].detach().to(p.device)
 
             # Normal behavior for later iterations
             self.error_feedback[n].add_(grad, alpha=lr)
@@ -556,7 +556,10 @@ class Miner(BaseMinerNeuron):
             xshapes[n] = xshape
             totalks[n] = totalk
 
-            del transmit_grad
+            del grad, transmit_grad, idxs, vals, xshape, totalk
+            if quantize:
+                del quant_params
+            gc.collect()
 
         # Delete graident iterator to free up memory
         del gradient_iterator

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -102,6 +102,7 @@ class Validator(BaseValidatorNeuron):
                 Point("allreduce_operations")
                 .tag("operation_id", str(op_id))
                 .tag("epoch", str(epoch))
+                .tag("run_id", __run__)
                 .tag("validator_uid", str(validator_uid))
                 .field("success_rate", float(success_rate))
                 .field("duration", float(duration))
@@ -138,7 +139,7 @@ class Validator(BaseValidatorNeuron):
                     .field("all_reduce_score", float(data.all_reduce.score))
                     .field("train_score", data.train.score)
                     .field("train_random_score", data.train.random.score)
-                    .field("train_assigned_score", data.train.assigned.score)
+                    .field("train_assigned_score", float(data.train.assigned.score))
                     .field("total_score", data.total.score)
                 )
                 points.append(point)
@@ -358,9 +359,10 @@ class Validator(BaseValidatorNeuron):
         if (self.uid == self.master_uid) or (
             "last_allreduce_block" not in self.model.config.__dict__
         ):
-            self.last_allreduce_block = self.block
+            self.last_allreduce_block = self.current_block
         else:
             self.last_allreduce_block = self.model.config.last_allreduce_block
+        self.blocks_since_allreduce = self.current_block - self.last_allreduce_block
 
     def _setup_uid_api(self):
         self.uid_api_url = self.config.neuron.uid_api_url


### PR DESCRIPTION
This PR addresses the following issues:

1. Validators showing signs of accumulating UID's train.assigned.score over time rather than averaging it. <==> This has been fixed by addressing the bug in thetrain.assigned.score moving average calculation that was the source of this.
2. Validators reaching full disk space whilst scoring uids. <==> This has been fixed through more frequent cache clearing calls.
3. Miners seeing 100% cpu utilization when uploading their gradients for the first time after an AllReduce. <==> We spent some time trying to recereate this issue and where only able to replicate it on an A40 with 50GB CPU memory and`torch 2.7.1+cu126 12.6 installed`. If we revert the machine back to the required `torch 2.5.1+cu124 12.4` the OOM issue doesn't occur. Interestingly also an A6000 with the same 50GBs of CPU memory doesn't face this issue. So we recommend that any miners facing this issue check their torch and cuda versions and rectify any mistmatches before running their miner. We've also added more aggressive variable deletion calls in miner.py to reduce the likelihood of this occuring if any.